### PR TITLE
不要なREAD_MEDIA権限をplugin.xmlから削除

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,8 +37,6 @@
       <uses-permission android:name="android.permission.CAMERA" />
       <uses-permission android:name="android.permission.RECORD_AUDIO" />
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-      <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-      <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
不要なREAD_MEDIA権限をplugin.xmlから削除
（Androidポリシー対応で漏れていたため追加）