### PR TITLE
CameraSessionManager​​cator.m, CameraSessionManager.h に #import <UIKit/UIKit.h> を追加

### DIFF
--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -1,3 +1,4 @@
+#import <UIKit/UIKit.h>
 #import <CoreImage/CoreImage.h>
 #import <AVFoundation/AVFoundation.h>
 #import "TemperatureAndTint.h"

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -1,4 +1,5 @@
 #include "CameraSessionManager.h"
+#import <UIKit/UIKit.h>
 
 @implementation CameraSessionManager
 


### PR DESCRIPTION
TODO：
Cordova13にアップグレード後、アプリビルドでエラーが発生したため修正を行います。
```
[14:14:50] /tmp/download/platforms/ios/App/Plugins/cordova-plugin-camera-preview/CameraSessionManager.m:682:25: error: use of undeclared identifier 'UIScreen'
[14:14:50]   682 |   CGRect screenRect = [[UIScreen mainScreen] bounds];
[14:14:50]       |                         ^
[14:14:50] /tmp/download/platforms/ios/App/Plugins/cordova-plugin-camera-preview/CameraSessionManager.m:707:14: error: use of undeclared identifier 'UIAlertView'
[14:14:50]   707 |           [[[UIAlertView alloc] initWithTitle:@"Error" 
[14:14:50]       |              ^
...
[14:14:51] ** ARCHIVE FAILED **
[14:14:51] Command failed with exit code 65: xcodebuild -workspace App.xcworkspace ...
```
```
[14:38:41] /tmp/download/platforms/ios/App/Plugins/cordova-plugin-camera-preview/CameraSessionManager.m:74:77: warning: conflicting parameter types in implementation of 'getCurrentOrientation:': '__strong id' vs 'UIInterfaceOrientation' (aka 'enum UIInterfaceOrientation') [-Wmismatched-parameter-types]
[14:38:41]    74 | - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
[14:38:41]       |                                                      ~~~~~~~~~~~~~~~~~~~~~~ ^
[14:38:41] In file included from /tmp/download/platforms/ios/App/Plugins/cordova-plugin-camera-preview/CameraSessionManager.m:1:
[14:38:41] /tmp/download/platforms/ios/App/Plugins/cordova-plugin-camera-preview/CameraSessionManager.h:39:77: note: previous definition is here
[14:38:41]    39 | - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
...
[14:38:41] 22 warnings and 2 errors generated.
[14:38:42] ** ARCHIVE FAILED **
[14:38:42] Command failed with exit code 65: xcodebuild -workspace App.xcworkspace ...
```


上記のログから、プラグインのCameraSessionManager.m内で UIScreen や UIAlertView が未定義として扱われ、エラーになっています。
そのため、CameraSessionManager​​cator.m, CameraSessionManager.h に #import <UIKit/UIKit.h> を明示的に定義します。